### PR TITLE
Show windows in one column if needed

### DIFF
--- a/plugin/committia.vim
+++ b/plugin/committia.vim
@@ -2,9 +2,11 @@ if (exists('g:loaded_committia') && g:loaded_committia) || &cp
     finish
 endif
 
+let g:committia_use_singlecolumn = get(g:, 'committia_use_singlecolumn', 'fallback')
 let g:committia_min_window_width = get(g:, 'committia_min_window_width', 160)
 let g:committia_diff_window_opencmd = get(g:, 'committia_diff_window_opencmd', 'botright vsplit')
 let g:committia_status_window_opencmd = get(g:, 'committia_status_window_opencmd', 'belowright split')
+let g:committia_singlecolumn_diff_window_opencmd = get(g:, 'committia_singlecolumn_diff_window_opencmd', 'belowright split')
 let g:committia_hooks = get(g:, 'committia_hooks', {})
 
 augroup plugin-committia


### PR DESCRIPTION
Show edit and diff window in one column if the window is too
narrow or told to do so.
