### PR TITLE
Do not remove commit message in squash mode

### DIFF
--- a/autoload/committia.vim
+++ b/autoload/committia.vim
@@ -46,7 +46,8 @@ endfunction
 
 function! s:remove_all_contents_except_for_commit_message()
     execute 0
-    call search('\m\%(\_^\s*\_$\n\)*\_^\s*#', 'cW')
+    " Handle squash message
+    call search('\m\%(\_^\s*\_$\n\)*\_^\s*# Please enter the commit', 'cW')
     normal! "_dG
     execute 0
     vertical resize 80


### PR DESCRIPTION
`rebase -i`からの`squash`時に元のメッセージまで消されると困るので直しました。

普通のコミットとsquashのコミットメッセージしかテストしてないので他のケースで
どうなるかは自信ないです。

見つからなかったら、以前の検索を行うとかやったほうがいいﾃﾞｽかね...?
