### PR TITLE
Fix regexp pattern searching git-dir (via #4)

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -8,7 +8,7 @@ let g:committia#git#status_cmd = get(g:, 'committia#git#status_cmd', 'status -b'
 
 function! s:search_git_root()
     " '/.git' is unnecessary under submodule directory.
-    if expand('%:p') =~# '\([\\/].git\)\?[\\/]COMMIT_EDITMSG'
+    if expand('%:p') =~# '[\\/]\.git[\\/]\%(modules[\\/].\+[\\/]\)\?COMMIT_EDITMSG$'
         return expand('%:p:h')
     endif
 


### PR DESCRIPTION
1. '/.git' is unnecessary under submodule directory.
   
   ex)
   **Parent repository**: `C:\home\dotfiles`
   **Submodule repository**: `C:\home\dotfiles\.git\modules\dotfiles\.vim\bundle\restart.vim\COMMIT_EDITMSG`
   **Submodule path**: `C:\home\dotfiles\dotfiles\.vim\bundle\restart.vim`
2. Support 'noshellslash'.
