### PR TITLE
avoid wrong display of color codes

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -1,5 +1,5 @@
 let g:committia#git#cmd = get(g:, 'committia#git#cmd', 'git')
-let g:committia#git#diff_cmd = get(g:, 'committia#git#diff_cmd', 'diff -u --cached')
+let g:committia#git#diff_cmd = get(g:, 'committia#git#diff_cmd', 'diff -u --cached --no-color')
 let g:committia#git#status_cmd = get(g:, 'committia#git#status_cmd', 'status -b')
 
 if ! executable(g:committia#git#cmd)


### PR DESCRIPTION
this avoids wrong display of color codes by turning them explicitly off even if enabled in the gitconfig