### PR TITLE
Introduce s:opened_committa

### DIFF
--- a/autoload/committia.vim
+++ b/autoload/committia.vim
@@ -164,10 +164,10 @@ function! s:open_singlecolumn(vcs)
 endfunction
 
 function! committia#open(vcs)
-    if (exists('g:opened_committia') && g:opened_committia)
+    if (exists('s:opened_committia') && s:opened_committia)
         return
     endif
-    let g:opened_committia = 1
+    let s:opened_committia = 1
     let is_narrow = winwidth(0) < g:committia_min_window_width
     let use_singlecolumn
                 \ = g:committia_use_singlecolumn ==# 'always'

--- a/autoload/committia.vim
+++ b/autoload/committia.vim
@@ -164,6 +164,10 @@ function! s:open_singlecolumn(vcs)
 endfunction
 
 function! committia#open(vcs)
+    if (exists('g:opened_committia') && g:opened_committia)
+        return
+    endif
+    let g:opened_committia = 1
     let is_narrow = winwidth(0) < g:committia_min_window_width
     let use_singlecolumn
                 \ = g:committia_use_singlecolumn ==# 'always'


### PR DESCRIPTION
In my environment, committia#open() is  called twice after `git commit`. 
s:open_diff_window() is called twice and `setlocal nomodifiable` fails.

This PR is not appropriate on g:committia_open_only_vim_starting = 0 environment.