### PR TITLE
add vimproc support

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -25,7 +25,13 @@ function! s:search_git_dir() abort
 endfunction
 
 function! s:execute_git(cmd, git_dir) abort
-    return system(printf('%s --git-dir="%s" --work-tree="%s" %s', g:committia#git#cmd, a:git_dir, fnamemodify(a:git_dir, ':h'), a:cmd))
+    let command = printf('%s --git-dir="%s" --work-tree="%s" %s', g:committia#git#cmd, a:git_dir, fnamemodify(a:git_dir, ':h'), a:cmd)
+
+    if exists('g:loaded_vimproc')
+        return vimproc#system(command)
+    else
+        return system(command)
+    endif
 endfunction
 
 function! committia#git#diff(...) abort


### PR DESCRIPTION
The `system` command does not work at Git for Windows.
So use `vimproc#system` instead if it can be used.