### PR TITLE
Reset colors for `git status` command

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -1,6 +1,6 @@
 let g:committia#git#cmd = get(g:, 'committia#git#cmd', 'git')
 let g:committia#git#diff_cmd = get(g:, 'committia#git#diff_cmd', 'diff -u --cached --no-color --no-ext-diff')
-let g:committia#git#status_cmd = get(g:, 'committia#git#status_cmd', 'status -b')
+let g:committia#git#status_cmd = get(g:, 'committia#git#status_cmd', '-c color.status=false status -b')
 
 try
     silent call vimproc#version()


### PR DESCRIPTION
Problem: When the user defines non defualt colors for the status command,
         the status split is full of terminal escape sequences.

Solution: To solve the issue, reset the colors for the status command
          by setting the color.status to false for the command.