### PR TITLE
Use language neutral regex to find edit region

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -148,5 +148,5 @@ function! committia#git#status() abort
 endfunction
 
 function! committia#git#search_end_of_edit_region() abort
-    call search('\m\%(\_^\s*\_$\n\)*\_^\s*# Please enter \%(the\|a\) commit', 'cW')
+    call search('\m\%(\_^\s*\_$\n\)*\_^# ', 'cW')
 endfunction


### PR DESCRIPTION
I think, at least for me, #36  is caused by the language-dependent regular expression in git.vim. Just matching for the first comment line fixes the issue for me.