### PR TITLE
Use git environment variables if set

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -42,6 +42,11 @@ function! s:extract_first_line(str) abort
 endfunction
 
 function! s:search_git_dir_and_work_tree() abort
+    " Use environment variables if set
+    if !empty($GIT_DIR) && !empty($GIT_WORK_TREE)
+        return [$GIT_DIR, $GIT_WORK_TREE]
+    endif
+
     " '/.git' is unnecessary under submodule directory.
     let matched = matchlist(expand('%:p'), '[\\/]\.git[\\/]\%(\(modules\|worktrees\)[\\/].\+[\\/]\)\?\%(COMMIT_EDITMSG\|MERGE_MSG\)$')
     if len(matched) > 1

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -44,6 +44,9 @@ endfunction
 function! s:search_git_dir_and_work_tree() abort
     " Use environment variables if set
     if !empty($GIT_DIR) && !empty($GIT_WORK_TREE)
+        if !isdirectory($GIT_WORK_TREE)
+            throw 'Directory specified with $GIT_WORK_TREE does not exist: ' . $GIT_WORK_TREE
+        endif
         return [$GIT_DIR, $GIT_WORK_TREE]
     endif
 


### PR DESCRIPTION
Git also uses the `GIT_DIR` and `GIT_WORK_TREE` environment variables , which should be preferred if set.
This does not fix https://github.com/rhysd/committia.vim/issues/37 yet, but provides a base for vcsh to work. Vcsh only has to export those environment variables and it will work.
In the meantime, other scripts relying on those variables will work right away.