### PR TITLE
Drop empty lines

### DIFF
--- a/autoload/committia.vim
+++ b/autoload/committia.vim
@@ -32,6 +32,8 @@ function! s:open_window(vcs, type, info, ft) abort
     let a:info[a:type . '_winnr'] = bufwinnr(bufname)
     let a:info[a:type . '_bufnr'] = bufnr('%')
     call append(0, content)
+    " Remove the line which is part of an empty buffer.
+    $delete _
     execute 0
     execute 'setlocal ft=' . a:ft
     setlocal nonumber bufhidden=wipe buftype=nofile readonly nolist nobuflisted noswapfile nomodifiable nomodified

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -198,5 +198,9 @@ function! committia#git#end_of_edit_region_line() abort
         endif
         let line -= 1
     endwhile
+    if line > 1 && empty(getline(line - 1))
+        " Drop empty line before comment block.
+        let line -= 1
+    endif
     return line
 endfunction


### PR DESCRIPTION
I've noticed presence of trailing empty lines in all three windows, which isn't a big deal, but is annoying enough to want to get rid of them.