### PR TITLE
Allow edit window width to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Vim command which opens a diff window in multi-columns mode.
 
 Vim command which opens a diff window in single-column mode.
 
+### `g:committia_edit_window_width` (default: `80`)
+
+If committia.vim is in multi-columns mode, specifies the width of the edit window.
+
 ## Future
 
 - Cooperate with [vim-fugitive](https://github.com/tpope/vim-fugitive).

--- a/autoload/committia.vim
+++ b/autoload/committia.vim
@@ -3,6 +3,7 @@ set cpo&vim
 
 let g:committia_use_singlecolumn = get(g:, 'committia_use_singlecolumn', 'fallback')
 let g:committia_min_window_width = get(g:, 'committia_min_window_width', 160)
+let g:committia_edit_window_width = get(g:, 'committia_edit_window_width', 80)
 let g:committia_diff_window_opencmd = get(g:, 'committia_diff_window_opencmd', 'botright vsplit')
 let g:committia_status_window_opencmd = get(g:, 'committia_status_window_opencmd', 'belowright split')
 let g:committia_singlecolumn_diff_window_opencmd = get(g:, 'committia_singlecolumn_diff_window_opencmd', 'belowright split')
@@ -74,7 +75,7 @@ function! s:remove_all_contents_except_for_commit_message(vcs) abort
         execute 'silent' line . ',$delete _'
     endif
     1
-    vertical resize 80
+    execute 'vertical resize' g:committia_edit_window_width
 endfunction
 
 function! s:callback_on_window_closed() abort


### PR DESCRIPTION
Only impacts double-column mode. Defaults to 80 (original setting) but allows the user to override the width of the double-column editor

In practice, I had other plugins that did things (line numbers, gutter, columns, etc.) that made a width of 80 a little too narrow so I'd end up with "wrap" inside the editor window which made it difficult to read for multi-line wrapping comments

Closes #50