### PR TITLE
fix behavior of `git-status` after committing

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -155,7 +155,7 @@ function! s:ensure_index_file(git_dir) abort
 endfunction
 
 function! s:unset_index_file() abort
-    let $GIT_INDEX_FILE = ''
+    unlet $GIT_INDEX_FILE
 endfunction
 
 function! committia#git#diff() abort


### PR DESCRIPTION
The value returned by the `git status` command varies depending on whether `$GIT_INDEX_FILE` is an empty string or undefined.

Sorry, I could not find any documentation that defines this behavior.