### PR TITLE
Improve support for amending git commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ If committia.vim is in multi-columns mode, specifies the width of the edit windo
 
 Minimum height of a status window.
 
+### `g:committia#git#use_verbose` (default: `0`)
+
+If the value is `1`, extract the diff and status from `COMMIT_EDITMSG` when the
+`verbose` option is used with `git commit`, e.g. `git commit --verbose` or `git
+config --global commit.verbose=true`.
+
 ## Future
 
 - Cooperate with [vim-fugitive](https://github.com/tpope/vim-fugitive).

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -199,7 +199,7 @@ function! s:comment_char() abort
     if line == 0
         let line = line('$') + 1
     endif
-    if match(getline(line - 1), '^[#;@!$%^&|:]') == 0
+    if getline(line - 1) =~# '^[#;@!$%^&|:]'
         return getline(line - 1)[0]
     else
         return '#'
@@ -226,7 +226,7 @@ function! committia#git#status() abort
             let status_start = scissors_line
             let re_status_start = '^[#;@!$%^&|:] ' . split(status, '\n')[0]
             while status_start > 1
-                if match(getline(status_start - 1), re_status_start) == 0
+                if getline(status_start - 1) =~# re_status_start
                     break
                 endif
                 let status_start -= 1
@@ -248,7 +248,7 @@ function! committia#git#end_of_edit_region_line() abort
         let line = line('$') + 1
     endif
     while line > 1
-        if match(getline(line - 1), '^' . s:comment_char() ) == -1
+        if getline(line - 1) !~# '^' . s:comment_char()
             break
         endif
         let line -= 1

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -202,7 +202,7 @@ function! committia#git#status() abort
         " localisation hack, find the start of the status in the commit
         " message template using the first line of output from `git status`
         let status_start = search(split(status, '\n')[0], 'cenW')
-        let status_end = s:diff_start_line()
+        let status_end = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
         if status_start > 0 && status_end > 0
             return getline(status_start, status_end-1)
         endif

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -203,12 +203,20 @@ function! committia#git#status() abort
     endtry
     if g:committia#git#use_verbose || exists('s:use_verbose_status')
         if exists('s:use_verbose_status') | unlet s:use_verbose_status | end
-        " localisation hack, find the start of the status in the commit
-        " message template using the first line of output from `git status`
-        let status_start = search(split(status, '\n')[0], 'cenW')
         let status_end = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
-        if status_start > 0 && status_end > 0
-            return getline(status_start, status_end-1)
+        if status_end > 0
+            " Save cursor position so we can restore it after searching
+            " backwards from the end of the status (i.e. scissors line)
+            " Search backwards to allow for non-default core.commentChar
+            let save_cursor = getcurpos()
+            call cursor(status_end, 1)
+            " localisation hack, find the start of the status in the commit
+            " message template using the first line of output from `git status`
+            let status_start = search(split(status, '\n')[0], 'benW')
+            call setpos('.', save_cursor)
+            if status_start > 0
+                return getline(status_start, status_end-1)
+            endif
         endif
     endif
     return map(split(status, '\n'), 'substitute(v:val, "^", "# ", "g")')

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -202,20 +202,22 @@ function! committia#git#status() abort
         return ''
     endtry
     if g:committia#git#use_verbose || exists('s:use_verbose_status')
-        if exists('s:use_verbose_status') | unlet s:use_verbose_status | end
-        let status_end = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
-        if status_end > 0
+        if exists('s:use_verbose_status')
+            unlet s:use_verbose_status
+        end
+        let scissors_line = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
+        if scissors_line > 0
             " Save cursor position so we can restore it after searching
             " backwards from the end of the status (i.e. scissors line)
             " Search backwards to allow for non-default core.commentChar
             let save_cursor = getcurpos()
-            call cursor(status_end, 1)
+            call cursor(scissors_line, 1)
             " localisation hack, find the start of the status in the commit
             " message template using the first line of output from `git status`
             let status_start = search(split(status, '\n')[0], 'benW')
             call setpos('.', save_cursor)
             if status_start > 0
-                return getline(status_start, status_end-1)
+                return getline(status_start, scissors_line-1)
             endif
         endif
     endif

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -176,12 +176,15 @@ function! committia#git#diff() abort
         return split(diff, '\n')
     endif
 
-    " FIXME: leads to inaccurate status with git commit --amend --verbose
-    " Extracted diff shows existing changes, but status will show no changes
     let line = s:diff_start_line()
     if line == 0
         return ['']
     endif
+
+    " Fugly hack to tell committia#git#status() to get the status from the
+    " commit message template too, otherwise status may not match with diff
+    " Could be removed if g:committia#git#use_verbose was enabled by default
+    let s:use_verbose_status = 1
 
     return getline(line, '$')
 endfunction
@@ -198,7 +201,8 @@ function! committia#git#status() abort
         " Leave status window empty when git-dir or work-tree not found
         return ''
     endtry
-    if g:committia#git#use_verbose
+    if g:committia#git#use_verbose || exists('s:use_verbose_status')
+        if exists('s:use_verbose_status') | unlet s:use_verbose_status | end
         " localisation hack, find the start of the status in the commit
         " message template using the first line of output from `git status`
         let status_start = search(split(status, '\n')[0], 'cenW')

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -207,10 +207,16 @@ function! committia#git#status() abort
         end
         let scissors_line = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
         if scissors_line > 0
+            " Save cursor position so we can restore it after searching
+            " backwards from the end of the status (i.e. scissors line)
+            " Search backwards to allow for non-default core.commentChar
+            let save_cursor = getcurpos()
+            call cursor(scissors_line, 1)
             " localisation hack, find the start of the status in the commit
             " message template using the first line of output from `git status`
-            let status_start = search('^[#;@!$%^&|:] ' . split(status, '\n')[0], 'benw')
-            if status_start > 0 && status_start < scissors_line
+            let status_start = search(split(status, '\n')[0], 'benW')
+            call setpos('.', save_cursor)
+            if status_start > 0
                 return getline(status_start, scissors_line-1)
             endif
         endif

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -194,6 +194,18 @@ function! s:diff_start_line() abort
     return search(re_start_diff_line, 'cenW')
 endfunction
 
+function! s:comment_char() abort
+    let line = s:diff_start_line()
+    if line == 0
+        let line = line('$') + 1
+    endif
+    if match(getline(line - 1), '^[#;@!$%^&|:]') == 0
+        return getline(line - 1)[0]
+    else
+        return '#'
+    endif
+endfunction
+
 function! committia#git#status() abort
     try
         let status = s:execute_git(g:committia#git#status_cmd)
@@ -224,7 +236,7 @@ function! committia#git#status() abort
             endif
         endif
     endif
-    return map(split(status, '\n'), 'substitute(v:val, "^", "# ", "g")')
+    return map(split(status, '\n'), 'substitute(v:val, "^", s:comment_char() . " ", "g")')
 endfunction
 
 function! committia#git#end_of_edit_region_line() abort
@@ -235,9 +247,8 @@ function! committia#git#end_of_edit_region_line() abort
         " Only the comment block will be removed from edit buffer. (#41)
         let line = line('$') + 1
     endif
-    let commentChar = getline(line - 1)[0]
     while line > 1
-        if match(getline(line - 1), '^'.commentChar) == -1
+        if match(getline(line - 1), '^' . s:comment_char() ) == -1
             break
         endif
         let line -= 1

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -206,17 +206,20 @@ function! committia#git#status() abort
             unlet s:use_verbose_status
         end
         let scissors_line = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
-        if scissors_line > 0
-            " Save cursor position so we can restore it after searching
-            " backwards from the end of the status (i.e. scissors line)
-            " Search backwards to allow for non-default core.commentChar
-            let save_cursor = getcurpos()
-            call cursor(scissors_line, 1)
-            " localisation hack, find the start of the status in the commit
+        if scissors_line > 1
+            " Localisation hack, find the start of the status in the commit
             " message template using the first line of output from `git status`
-            let status_start = search(split(status, '\n')[0], 'benW')
-            call setpos('.', save_cursor)
-            if status_start > 0
+            " Search backwards to avoid match in message, and start search at
+            " scissors line to avoid potential match in diff, unlikely, but...
+            let status_start = scissors_line
+            let re_status_start = '^[#;@!$%^&|:] ' . split(status, '\n')[0]
+            while status_start > 1
+                if match(getline(status_start - 1), re_status_start) == 0
+                    break
+                endif
+                let status_start -= 1
+            endwhile
+            if status_start > 1 && status_start < scissors_line
                 return getline(status_start, scissors_line-1)
             endif
         endif

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -187,8 +187,7 @@ function! committia#git#diff() abort
 endfunction
 
 function! s:diff_start_line() abort
-    " FIXME: allow for other git comment character (# is just the default)
-    let re_start_diff_line = '# -\+ >8 -\+\n\%(#.*\n\)\+diff --git'
+    let re_start_diff_line = '^[#;@!$%^&|:] -\+ >8 -\+\n\%([#;@!$%^&|:].*\n\)\+diff --git'
     return search(re_start_diff_line, 'cenW')
 endfunction
 

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -248,7 +248,7 @@ function! committia#git#end_of_edit_region_line() abort
         let line = line('$') + 1
     endif
     while line > 1
-        if getline(line - 1) !~# '^' . s:comment_char()
+        if stridx(getline(line - 1), s:comment_char()) != 0
             break
         endif
         let line -= 1

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -235,8 +235,9 @@ function! committia#git#end_of_edit_region_line() abort
         " Only the comment block will be removed from edit buffer. (#41)
         let line = line('$') + 1
     endif
+    let commentChar = getline(line - 1)[0]
     while line > 1
-        if match(getline(line - 1), '^[#;@!$%^&|:]') == -1
+        if match(getline(line - 1), '^'.commentChar) == -1
             break
         endif
         let line -= 1

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -233,7 +233,7 @@ function! committia#git#end_of_edit_region_line() abort
         let line = line('$') + 1
     endif
     while line > 1
-        if stridx(getline(line - 1), '#') != 0
+        if match(getline(line - 1), '^[#;@!$%^&|:]') == -1
             break
         endif
         let line -= 1

--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -207,16 +207,10 @@ function! committia#git#status() abort
         end
         let scissors_line = search('^[#;@!$%^&|:] -\+ >8 -\+\n', 'cenW')
         if scissors_line > 0
-            " Save cursor position so we can restore it after searching
-            " backwards from the end of the status (i.e. scissors line)
-            " Search backwards to allow for non-default core.commentChar
-            let save_cursor = getcurpos()
-            call cursor(scissors_line, 1)
             " localisation hack, find the start of the status in the commit
             " message template using the first line of output from `git status`
-            let status_start = search(split(status, '\n')[0], 'benW')
-            call setpos('.', save_cursor)
-            if status_start > 0
+            let status_start = search('^[#;@!$%^&|:] ' . split(status, '\n')[0], 'benw')
+            if status_start > 0 && status_start < scissors_line
                 return getline(status_start, scissors_line-1)
             endif
         endif


### PR DESCRIPTION
This really a feature suggestion supplied with working code. There are a few niggles when amending git commits which in the past put me off using committia, which I've tried to address here...

When amending a commit there was no way to explicitly tell committia to show the full diff of all changes introduced by the commit, it would show you either the new changes, if there were any (i.e. `git diff` showed some changes), or, if the verbose option was provided to git commit, fall back to showing the full diff extracted from the commit message template, otherwise do nothing. When falling back to showing the full diff extracted from the commit message template, the status would not match the diff, with the diff showing changes, but status showing no changes.

This PR introduces a new opt-in feature to always extract status and diff from the commit message template when the verbose option is enabled for git commit, e.g. `git commit --verbose` or `git config --global commit.verbose=true`. This allows users to choose to see only the new changes when amending commits, e.g. `git commit --amend -a`, or show all changes, e.g. `git commit --amend -av`.

I find this really useful as I often want to see the entire diff when amending a commit and updating the message.

I've also added an, admittedly fugly, hack to fix the fall back issue with the status not matching the diff, and updated the regex to find the diff start line in the commit message template to allow for non-default git config core.commentChar, e.g. `;`

Let me know what you think, I can supply some screenshots explaining in more detail if I've not made myself clear above.

