### PR TITLE
Trim extracted `work_tree`

### DIFF
--- a/autoload/committia/git.vim
+++ b/autoload/committia/git.vim
@@ -95,7 +95,7 @@ function! s:search_git_dir_and_work_tree() abort
             endif
         endtry
 
-        let work_tree = s:extract_first_line(out)
+        let work_tree = trim(s:extract_first_line(out))
         return [git_dir, work_tree]
     endif
 


### PR DESCRIPTION
It still may contain newlines after extraction.

For some reason recently I started to receive the following error when committia loads up:
```
Error detected while processing BufReadPost Autocommands for "COMMIT_EDITMSG"..function committia#open[21]..committia#open_multicolumn[3]..<SNR>55_open_diff_window[1]..<SNR>55_open_window[1]..committia#git#diff[8]..<SNR>56_execute_gi
t[27]..BufReadPost Autocommands for "COMMIT_EDITMSG"..function committia#open[21]..committia#open_multicolumn[3]..<SNR>55_open_diff_window[1]..<SNR>55_open_window[1]..committia#git#diff[8]..<SNR>56_execute_git:
line   21:
E605: Exception not caught: committia: git: Failed to execute command 'git --git-dir="/Users/iurazov/.local/dotfiles/.git" --work-tree="
/Users/iurazov/.local/dotfiles
" diff -u --cached --no-color --no-ext-diff':
fatal: Invalid path '/Users/iurazov/.local/dotfiles/
': No such file or directory
```

It looks like `work_tree` variable contains newlines at the begining and end of line. I wasn't able to track how this happens, so decided to do a `trim()` after extraction is complete.

Side note, I'm using neovim v0.11.2, but occurance of this problem with committia doesn't correlate with nvim version upgrade in my case.